### PR TITLE
Updated manifest.json to be compatible with latest HA versions.

### DIFF
--- a/custom_components/senec/manifest.json
+++ b/custom_components/senec/manifest.json
@@ -7,11 +7,10 @@
   "requirements": [
     "pysenec==0.1.0"
   ],
-  "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
   "dependencies": [],
   "codeowners": [
     "@mchwalisz"
-  ]
+  ],
+  "iot_class": "local_polling",
+  "version": "0.0.1"
 }


### PR DESCRIPTION
The custom component doesn't show up as an integration until adding the `iot_class` property (and maybe also `version`).
Tested with core-2021.6.3 and supervisor-2021.05.4