### PR TITLE
Feature configurable scan interval (#29)

### DIFF
--- a/custom_components/senec/config_flow.py
+++ b/custom_components/senec/config_flow.py
@@ -3,15 +3,16 @@ import logging
 from urllib.parse import ParseResult, urlparse
 
 import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import slugify
 from pysenec import Senec
 from requests.exceptions import HTTPError, Timeout
 
 from .const import DOMAIN  # pylint:disable=unused-import
-from .const import DEFAULT_HOST, DEFAULT_NAME
+from .const import DEFAULT_HOST, DEFAULT_NAME, DEFAULT_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ def senec_entries(hass: HomeAssistant):
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for senec."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def _host_in_configuration_exists(self, host) -> bool:
@@ -56,16 +57,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # set some defaults in case we need to return to the form
             name = slugify(user_input.get(CONF_NAME, DEFAULT_NAME))
             host_entry = user_input.get(CONF_HOST, DEFAULT_HOST)
+            scan_interval = user_input.get(CONF_HOST, DEFAULT_HOST)
 
+            if scan_interval < 5:
+                self._errors[CONF_SCAN_INTERVAL] = "scan interval too low"
             if self._host_in_configuration_exists(host_entry):
                 self._errors[CONF_HOST] = "already_configured"
             else:
                 if await self._test_connection(host_entry):
-                    return self.async_create_entry(title=name, data={CONF_HOST: host_entry})
+                    return self.async_create_entry(title=name, data={CONF_HOST: host_entry}, options={CONF_SCAN_INTERVAL: scan_interval})
         else:
             user_input = {}
             user_input[CONF_NAME] = DEFAULT_NAME
             user_input[CONF_HOST] = DEFAULT_HOST
+            user_input[CONF_SCAN_INTERVAL] = DEFAULT_SCAN_INTERVAL
 
         return self.async_show_form(
             step_id="user",
@@ -73,6 +78,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)): str,
                     vol.Required(CONF_HOST, default=user_input.get(CONF_HOST, DEFAULT_HOST)): str,
+                    vol.Required(CONF_SCAN_INTERVAL, default=user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)): cv.positive_int,
                 }
             ),
             errors=self._errors,

--- a/custom_components/senec/const.py
+++ b/custom_components/senec/const.py
@@ -16,6 +16,7 @@ DOMAIN = "senec"
 """Default config for Senec."""
 DEFAULT_HOST = "Senec"
 DEFAULT_NAME = "senec"
+DEFAULT_SCAN_INTERVAL = 60
 
 """Fixed constants."""
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/custom_components/senec/const.py
+++ b/custom_components/senec/const.py
@@ -1,14 +1,16 @@
 """Constants for the Senec integration."""
-from collections import namedtuple
-from datetime import timedelta
-from typing import Final
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, PERCENTAGE, POWER_WATT, TEMP_CELSIUS
+from homeassistant.const import (
+    ENERGY_KILO_WATT_HOUR,
+    PERCENTAGE,
+    POWER_WATT,
+    TEMP_CELSIUS,
+)
 
 DOMAIN = "senec"
 
@@ -17,9 +19,6 @@ DOMAIN = "senec"
 DEFAULT_HOST = "Senec"
 DEFAULT_NAME = "senec"
 DEFAULT_SCAN_INTERVAL = 60
-
-"""Fixed constants."""
-SCAN_INTERVAL = timedelta(seconds=60)
 
 """Supported sensor types."""
 

--- a/custom_components/senec/strings.json
+++ b/custom_components/senec/strings.json
@@ -1,11 +1,19 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "data" : {
+          "scan_interval": "Polling interval (s)"
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "scan_interval": "Polling interval (s)"
         }
       }
     },

--- a/custom_components/senec/translations/en.json
+++ b/custom_components/senec/translations/en.json
@@ -1,4 +1,13 @@
 {
+    "options": {
+        "step": {
+            "init": {
+                "data" : {
+                    "scan_interval": "Polling interval (s)"
+                }
+            }
+        }
+    },
     "config": {
         "abort": {
             "already_configured": "Integration is already configured"
@@ -10,7 +19,8 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "IP or hostname of the Senec Device"
+                    "host": "IP or hostname of the Senec Device",
+                    "scan_interval": "Polling interval (s)"
                 }
             }
         }


### PR DESCRIPTION
This PR fixes #29  by making the scan-interval configurable: 
* Add scan-interval as data to be entered when adding the integration (default remains 60s, minimum 5s)
* Add config-flow migration, updating existing configurations by adding new scan-interval data
* Add option-flow, allowing to update the scan-interval w/o re-installing the integration

Notes to @mchwalisz : 
* I've developed code within the home-assistant dev-container, using it's default formatting. So please excuse the formatting changes 🙈 
* I've removed some unused imports. Hope the un-related cleanup is okay

Looking forward for your feedback!